### PR TITLE
feat: add eslintrc

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,47 +2,31 @@
 
 eslint/stylelint/...
 
+## Features
+
+- [x] eslint
+- [x] stylelint
+- [ ] prettier
+- [ ] eslint support TypeScript
+
 ## Install
 
-```
+```bash
 $ npm i --save-dev @ice/spec
 ```
+
+You don't need dep eslint/stylelint/eslin-plugin-*/... in your project.
 
 ## Usage
 
 ### eslint
 
-1. Install the correct versions of each package, which are listed by the command:
-
-```bash
-npm info @ice/spec peerDependencies
-```
-
-If using npm 5+, use this shortcut
-
-```bash
-npx install-peerdeps --dev @ice/spec
-```
-
-2. Create a `.eslintrc.js`
+Create a `.eslintrc.js`
 
 ```js
 const { eslint } = require('@ice/spec');
 
 module.exports = eslint;
-```
-
-3. Enabling ESLint on TS files in VSCode (Optional)
-
-by default the ESLint plugin only runs on javascript and javascriptreact files. To tell it to run on TS files, you need to update the eslint.validate setting to:
-
-```json
-"eslint.validate": [
-  "javascript",
-  "javascriptreact",
-  "typescript",
-  "typescriptreact"
-]
 ```
 
 ### stylelint
@@ -55,12 +39,16 @@ const { stylelint } = require('@ice/spec');
 module.exports = stylelint;
 ```
 
-### prettier
+## FAQ
 
-in `.prettierrc.js`
+### Custom config
 
 ```js
-const { prettier } = require('@ice/spec');
+const { eslint, deepmerge } = require('@ice/spec');
 
-module.exports = prettier;
+module.exports = deepmerge(eslint, {
+  rules: {
+    // custom config
+  },
+});
 ```

--- a/README.md
+++ b/README.md
@@ -12,12 +12,37 @@ $ npm i --save-dev @ice/spec
 
 ### eslint
 
-in `.eslintrc.js`
+1. Install the correct versions of each package, which are listed by the command:
+
+```bash
+npm info @ice/spec peerDependencies
+```
+
+If using npm 5+, use this shortcut
+
+```bash
+npx install-peerdeps --dev @ice/spec
+```
+
+2. Create a `.eslintrc.js`
 
 ```js
-import { eslint } from '@ice/spec';
+const { eslint } = require('@ice/spec');
 
 module.exports = eslint;
+```
+
+3. Enabling ESLint on TS files in VSCode (Optional)
+
+by default the ESLint plugin only runs on javascript and javascriptreact files. To tell it to run on TS files, you need to update the eslint.validate setting to:
+
+```json
+"eslint.validate": [
+  "javascript",
+  "javascriptreact",
+  "typescript",
+  "typescriptreact"
+]
 ```
 
 ### stylelint
@@ -25,7 +50,7 @@ module.exports = eslint;
 in `.stylelint.js`
 
 ```js
-import { stylelint } from '@ice/spec';
+const { stylelint } = require('@ice/spec');
 
 module.exports = stylelint;
 ```
@@ -35,7 +60,7 @@ module.exports = stylelint;
 in `.prettierrc.js`
 
 ```js
-import { prettier } from '@ice/spec';
+const { prettier } = require('@ice/spec');
 
 module.exports = prettier;
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # spec
 
-eslint/stylelint/...
+eslint/stylelint/prettier config.
 
 ## Features
 
@@ -12,10 +12,8 @@ eslint/stylelint/...
 ## Install
 
 ```bash
-$ npm i --save-dev @ice/spec
+$ npm i --save-dev @ice/spec eslint stylelint
 ```
-
-You don't need dep eslint/stylelint/eslin-plugin-*/... in your project.
 
 ## Usage
 

--- a/lib/eslint.js
+++ b/lib/eslint.js
@@ -1,0 +1,65 @@
+module.exports = {
+  "parser": "@typescript-eslint/parser",
+  "plugins": ["@typescript-eslint"],
+  "extends": ["airbnb", "plugin:@typescript-eslint/recommended"],
+  "parserOptions": {
+    "ecmaFeatures": {
+      "jsx": true
+    }
+  },
+  "env": {
+    "es6": true,
+    "browser": true,
+    "jest": true,
+    "mocha": true,
+    "node": true,
+    "commonjs": true
+  },
+  "rules": {
+    "arrow-parens": [2, "always"],
+    "no-console": 0,
+    "no-use-before-define": 0,
+    "react/forbid-prop-types": 0,
+    "jsx-a11y/label-has-for": 0,
+    "jsx-a11y/no-static-element-interactions": 0,
+    "jsx-a11y/anchor-has-content": 0,
+    "jsx-a11y/click-events-have-key-events": 0,
+    "jsx-a11y/anchor-is-valid": 0,
+    "react/no-array-index-key": 0,
+    "func-names": 0,
+    "arrow-body-style": 0,
+    "react/sort-comp": 0,
+    "react/prop-types": 0,
+    "react/jsx-first-prop-new-line": 0,
+    "react/jsx-filename-extension": [
+      1,
+      {
+        "extensions": [".js", ".jsx"]
+      }
+    ],
+    "import/extensions": 0,
+    "import/no-unresolved": 0,
+    "import/no-extraneous-dependencies": 0,
+    "prefer-destructuring": 0,
+    "no-param-reassign": 0,
+    "no-return-assign": 0,
+    "max-len": 0,
+    "consistent-return": 0,
+    "no-redeclare": 0,
+    "react/require-extension": 0,
+    "react/no-danger": 0,
+    "comma-dangle": ["error", "always-multiline"],
+    "function-paren-newline": 0,
+    "object-curly-newline": 0,
+    "no-restricted-globals": 0,
+    "react/prefer-stateless-function": 0,
+    "react/jsx-no-bind": 0,
+    "no-plusplus": 0,
+    "global-require": 0,
+    "class-methods-use-this": 0,
+
+    "@typescript-eslint/array-type": ["error", "array"],
+    "@typescript-eslint/indent": ["error", 2],
+    "@typescript-eslint/no-use-before-define": 0
+  }
+}

--- a/lib/eslint.js
+++ b/lib/eslint.js
@@ -1,68 +1,107 @@
 module.exports = {
-  "parser": "@typescript-eslint/parser",
-  "plugins": ["@typescript-eslint", "react-hooks"],
-  "extends": ["airbnb", "plugin:@typescript-eslint/recommended"],
-  "parserOptions": {
-    "ecmaFeatures": {
-      "jsx": true
+  parser: "babel-eslint",
+  parserOptions: {
+    ecmaFeatures: {
+      jsx: true,
+      experimentalObjectRestSpread: true
     }
   },
-  "env": {
-    "es6": true,
-    "browser": true,
-    "jest": true,
-    "mocha": true,
-    "node": true,
-    "commonjs": true
+  // extends other config
+  extends: [
+    "airbnb",
+    "plugin:jsx-a11y/recommended",
+    "prettier",
+    "prettier/react"
+  ],
+  // use plugin for parse
+  plugins: [
+    "react",
+    "react-hooks",
+    "jsx-a11y"
+  ],
+  env: {
+    es6: true,
+    browser: true,
+    node: true
   },
-  "rules": {
-    "arrow-parens": [2, "always"],
-    "no-console": 0,
-    "no-use-before-define": 0,
-    "react/forbid-prop-types": 0,
-    "jsx-a11y/label-has-for": 0,
+  rules: {
+    /** react hooks https://reactjs.org/docs/hooks-rules.html */
+    "react-hooks/rules-of-hooks": "error",
+    "react-hooks/exhaustive-deps": "warn",
+
+    /** 无障碍相关 https://github.com/evcohen/eslint-plugin-jsx-a11y/tree/master/docs/rules */
+    // label htmlFor 属性或者用 label 把表单组件包起来：不强制
+    "jsx-a11y/label-has-associated-control": 1,
+    // 静态元素（div/span/...）不允许绑定事件，除非指定 role：允许
     "jsx-a11y/no-static-element-interactions": 0,
-    "jsx-a11y/anchor-has-content": 0,
+    // 支持 click 事件必须同时支持键盘事件：不要求
     "jsx-a11y/click-events-have-key-events": 0,
+    // 禁止不规则使用 a 标签：先允许吧
     "jsx-a11y/anchor-is-valid": 0,
+
+    /** react 相关 https://github.com/yannickcr/eslint-plugin-react/tree/master/docs/rules */
+    // index 不能作为 key
     "react/no-array-index-key": 0,
-    "func-names": 0,
-    "arrow-body-style": 0,
-    "react/sort-comp": 0,
+    // ???
+    "react/jsx-one-expression-per-line": 0,
+    // 必须声明 propTypes：做不到
     "react/prop-types": 0,
+    // ???
     "react/jsx-first-prop-new-line": 0,
+    // 使用 props/state/context 必须解构：不合理
+    "react/destructuring-assignment": 0,
+    // 禁止不具体的 propTypes 声明：有点难
+    "react/forbid-prop-types": 0,
     "react/jsx-filename-extension": [
       1,
       {
         "extensions": [".js", ".jsx"]
       }
     ],
-    "import/extensions": 0,
-    "import/no-unresolved": 0,
-    "import/no-extraneous-dependencies": 0,
-    "prefer-destructuring": 0,
-    "no-param-reassign": 0,
-    "no-return-assign": 0,
-    "max-len": 0,
-    "consistent-return": 0,
-    "no-redeclare": 0,
-    "react/require-extension": 0,
+    // "react/require-extension": 0,
+    // 不允许使用 dangerous 属性：允许
     "react/no-danger": 0,
+
+    /** import/export https://github.com/benmosher/eslint-plugin-import/tree/master/docs/rules */
+    // 必须写明文件类型：不需要
+    "import/extensions": 0,
+    // ???
+    "import/no-unresolved": 0,
+    // ???
+    "import/no-extraneous-dependencies": 0,
+
+    /** 基础语法规则 https://cn.eslint.org/docs/rules/ */
+    // 禁止 console.log：允许
+    "no-console": 0,
+    // 禁止变量声明与外层作用域的变量同名：允许但不推荐
+    "no-shadow": 1,
+    // 禁止未使用过的表达式：允许但不推荐，callback && callback()
+    "no-unused-expressions": 1,
+    // 禁止定义前使用：允许但不推荐，styles 放在最后声明（有待商榷）
+    "no-use-before-define": 1,
+    // 禁止直接调用 Object.prototypes 的内置属性：允许但不推荐，obj.hasOwnProperty('key')
+    "no-prototype-builtins": 1,
+    // 禁止匿名函数：没必要
+    "func-names": 0,
+    // 箭头函数必须使用大括号：没必要
+    "arrow-body-style": 0,
+    // 优先使用解构：没必要
+    "prefer-destructuring": 0,
+    // 禁止对 function 的参数进行重新赋值：的确应该禁止???
+    "no-param-reassign": 1,
+    // 禁止在 return 语句中使用赋值语句：不确定???
+    "no-return-assign": 0,
+    // 强制一行的最大长度：没必要
+    "max-len": 0,
+    // 函数必须有返回值：不确定???
+    "consistent-return": 0,
+    // 拖尾逗号
     "comma-dangle": ["error", "always-multiline"],
+    // ???
     "function-paren-newline": 0,
+    // ???
     "object-curly-newline": 0,
+    // 禁用特定的全局变量：没必要
     "no-restricted-globals": 0,
-    "react/prefer-stateless-function": 0,
-    "react/jsx-no-bind": 0,
-    "no-plusplus": 0,
-    "global-require": 0,
-    "class-methods-use-this": 0,
-
-    "react-hooks/rules-of-hooks": 'error',
-    "react-hooks/exhaustive-deps": 'warn',
-
-    "@typescript-eslint/array-type": ["error", "array"],
-    "@typescript-eslint/indent": ["error", 2],
-    "@typescript-eslint/no-use-before-define": 0
   }
 }

--- a/lib/eslint.js
+++ b/lib/eslint.js
@@ -1,6 +1,6 @@
 module.exports = {
   "parser": "@typescript-eslint/parser",
-  "plugins": ["@typescript-eslint"],
+  "plugins": ["@typescript-eslint", "react-hooks"],
   "extends": ["airbnb", "plugin:@typescript-eslint/recommended"],
   "parserOptions": {
     "ecmaFeatures": {
@@ -57,6 +57,9 @@ module.exports = {
     "no-plusplus": 0,
     "global-require": 0,
     "class-methods-use-this": 0,
+
+    "react-hooks/rules-of-hooks": 'error',
+    "react-hooks/exhaustive-deps": 'warn',
 
     "@typescript-eslint/array-type": ["error", "array"],
     "@typescript-eslint/indent": ["error", 2],

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,7 @@
 module.exports = {
   eslint: require('./eslint'),
   stylelint: require('./stylelint'),
-  prettier: require('./prettier')
+  prettier: require('./prettier'),
+
+  deepmerge: require('deepmerge'),
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,3 @@
-
 module.exports = {
   eslint: require('./eslint'),
   stylelint: require('./stylelint'),

--- a/lib/stylelint.js
+++ b/lib/stylelint.js
@@ -1,0 +1,14 @@
+module.exports = {
+  extends: [
+    "stylelint-config-standard",
+    "stylelint-config-css-modules",
+    "stylelint-scss",
+    "stylelint-config-rational-order",
+    "stylelint-config-prettier",
+  ],
+  plugins: [
+    "stylelint-order",
+  ],
+  rules: {
+  }
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ice/spec",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "eslint/stylelint/editorconfig",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "eslint-config-airbnb": "^17.1.1",
     "eslint-plugin-import": "^2.18.0",
     "eslint-plugin-jsx-a11y": "^6.2.3",
-    "eslint-plugin-react": "^7.14.2"
+    "eslint-plugin-react": "^7.14.2",
+    "eslint-plugin-react-hooks": "^1.6.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ice/spec",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "eslint/stylelint/editorconfig",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
   "dependencies": {
     "babel-eslint": "^10.0.2",
     "deepmerge": "^3.3.0",
-    "eslint": "^5.16.0",
     "eslint-config-airbnb": "^17.1.1",
     "eslint-config-prettier": "^6.0.0",
     "eslint-plugin-babel": "^5.3.0",
@@ -29,7 +28,6 @@
     "eslint-plugin-jsx-a11y": "^6.2.3",
     "eslint-plugin-react": "^7.14.2",
     "eslint-plugin-react-hooks": "^1.6.1",
-    "stylelint": "^10.1.0",
     "stylelint-config-css-modules": "^1.4.0",
     "stylelint-config-prettier": "^5.2.0",
     "stylelint-config-rational-order": "^0.1.2",

--- a/package.json
+++ b/package.json
@@ -18,14 +18,23 @@
     "access": "public"
   },
   "homepage": "https://github.com/ice-lab/spec#readme",
-  "peerDependencies": {
+  "dependencies": {
+    "babel-eslint": "^10.0.2",
+    "deepmerge": "^3.3.0",
     "eslint": "^5.16.0",
-    "@typescript-eslint/eslint-plugin": "^1.11.0",
-    "@typescript-eslint/parser": "^1.11.0",
     "eslint-config-airbnb": "^17.1.1",
+    "eslint-config-prettier": "^6.0.0",
+    "eslint-plugin-babel": "^5.3.0",
     "eslint-plugin-import": "^2.18.0",
     "eslint-plugin-jsx-a11y": "^6.2.3",
     "eslint-plugin-react": "^7.14.2",
-    "eslint-plugin-react-hooks": "^1.6.1"
+    "eslint-plugin-react-hooks": "^1.6.1",
+    "stylelint": "^10.1.0",
+    "stylelint-config-css-modules": "^1.4.0",
+    "stylelint-config-prettier": "^5.2.0",
+    "stylelint-config-rational-order": "^0.1.2",
+    "stylelint-config-standard": "^18.3.0",
+    "stylelint-order": "^3.0.0",
+    "stylelint-scss": "^3.8.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,5 +17,14 @@
   "publishConfig": {
     "access": "public"
   },
-  "homepage": "https://github.com/ice-lab/spec#readme"
+  "homepage": "https://github.com/ice-lab/spec#readme",
+  "peerDependencies": {
+    "eslint": "^5.16.0",
+    "@typescript-eslint/eslint-plugin": "^1.11.0",
+    "@typescript-eslint/parser": "^1.11.0",
+    "eslint-config-airbnb": "^17.1.1",
+    "eslint-plugin-import": "^2.18.0",
+    "eslint-plugin-jsx-a11y": "^6.2.3",
+    "eslint-plugin-react": "^7.14.2"
+  }
 }


### PR DESCRIPTION
1. eslint规则
2. eslint规则使用文档

因为eslint使用时要求plugin等依赖必须在顶层依赖，所以这边用peerDependences的形式，参考airbnb规则的实现https://www.npmjs.com/package/eslint-config-airbnb