### PR TITLE
fix: deep merge new attribute

### DIFF
--- a/lib/deepmerge.js
+++ b/lib/deepmerge.js
@@ -6,9 +6,9 @@ module.exports = function(target, source) {
     const type = Object.prototype.toString.call(source[key]);
 
     if (type === '[object Array]') {
-      newObj[key] = [...target[key], ...source[key]];
+      newObj[key] = [...(target[key] || []), ...source[key]];
     } else if (type === '[object Object]') {
-      newObj[key] = {...target[key], ...source[key]};
+      newObj[key] = {...(target[key] || {}), ...source[key]};
     } else {
       newObj[key] = source[key];
     }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -42,3 +42,14 @@ it('plugins should be merged', () => {
   expect(result.plugins[0]).toEqual('react-hooks');
   expect(result.plugins[1]).toEqual('react-xxx');
 });
+
+it('new attributes should be merged', () => {
+  const result = deepmerge(eslint, {
+    newAttribute1: ['xxxx-val1'],
+    newAttribute2: { a: 'xxxx-val2' },
+    newAttribute3: 'xxxx-val3'
+  });
+  expect(result.newAttribute1[0]).toEqual('xxxx-val1');
+  expect(result.newAttribute2.a).toEqual('xxxx-val2');
+  expect(result.newAttribute3).toEqual('xxxx-val3');
+});


### PR DESCRIPTION
#13 修复 `deepmerge`中合并`target`问题。

当`souce`中的`key`不存在于`target`中时报错 `Error: target[key] is not iterable`  

报错示例如下：
```js
const eslint = require('./eslint');
const deepmerge = require('./deepmerge');

// eslint 无 overrides key
// 此处会抛出错误 Error: target[key] is not iterable` 
module.exports = deepmerge(eslint, {
  overrides: [
    {
      files: ['*.js'],
      rules: {
        '@typescript-eslint/no-var-requires': 'off',
      },
    },
  ],
});
```