### PR TITLE
Fix: eslint's plugin not found in jest env

### DIFF
--- a/packages/eslint-plugin-best-practices/package.json
+++ b/packages/eslint-plugin-best-practices/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iceworks/eslint-plugin-best-practices",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Iceworks best practices eslint plugin.",
   "files": [
     "docs/",
@@ -23,7 +23,7 @@
     "fs-extra": "^9.0.1",
     "line-column": "^1.0.2",
     "path-to-regexp": "^6.1.0",
-    "requireindex": "~1.1.0",
+    "require-all": "^3.0.0",
     "semver": "^7.3.2"
   },
   "devDependencies": {

--- a/packages/eslint-plugin-best-practices/src/index.js
+++ b/packages/eslint-plugin-best-practices/src/index.js
@@ -1,13 +1,13 @@
 const path = require('path');
-const requireAll = require('require-all')
+const requireAll = require('require-all');
 
 exports.rules = requireAll({
   dirname: path.resolve(__dirname, 'rules'),
-})
+});
 
 exports.configs = requireAll({
   dirname: path.resolve(__dirname, 'configs'),
-})
+});
 
 exports.processors = {
   '.json': {

--- a/packages/eslint-plugin-best-practices/src/index.js
+++ b/packages/eslint-plugin-best-practices/src/index.js
@@ -1,7 +1,14 @@
-const requireIndex = require('requireindex');
+const path = require('path');
+const requireAll = require('require-all')
 
-exports.rules = requireIndex(`${__dirname}/rules`);
-exports.configs = requireIndex(`${__dirname}/configs`);
+exports.rules = requireAll({
+  dirname: path.resolve(__dirname, 'rules'),
+})
+
+exports.configs = requireAll({
+  dirname: path.resolve(__dirname, 'configs'),
+})
+
 exports.processors = {
   '.json': {
     preprocess(text) {

--- a/packages/spec/package.json
+++ b/packages/spec/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iceworks/spec",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Easy to use eslint/stylelint/prettier/commitlint in rax, ice and react project.",
   "main": "src/index.js",
   "files": [
@@ -40,7 +40,7 @@
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-react": "^7.21.5",
     "eslint-plugin-react-hooks": "^4.2.0",
-    "requireindex": "^1.2.0",
+    "require-all": "^3.0.0",
     "stylelint-config-ali": "^0.3.4",
     "stylelint-scss": "^3.18.0"
   },

--- a/packages/spec/src/index.js
+++ b/packages/spec/src/index.js
@@ -1,8 +1,10 @@
 const deepmerge = require('./deepmerge');
-const eslint = require('requireindex')(`${__dirname}/eslint`);
-const stylelint = require('requireindex')(`${__dirname}/stylelint`);
-const prettier = require('requireindex')(`${__dirname}/prettier`);
-const commitlint = require('requireindex')(`${__dirname}/commitlint`);
+const requireAll = require('require-all');
+
+const eslint = requireAll(`${__dirname}/eslint`);
+const stylelint = requireAll(`${__dirname}/stylelint`);
+const prettier = requireAll(`${__dirname}/prettier`);
+const commitlint = requireAll(`${__dirname}/commitlint`);
 
 function getConfig(configs, rule, customConfig) {
   if (!configs[rule]) {

--- a/packages/spec/src/index.js
+++ b/packages/spec/src/index.js
@@ -1,10 +1,19 @@
+const path = require('path');
 const deepmerge = require('./deepmerge');
 const requireAll = require('require-all');
 
-const eslint = requireAll(`${__dirname}/eslint`);
-const stylelint = requireAll(`${__dirname}/stylelint`);
-const prettier = requireAll(`${__dirname}/prettier`);
-const commitlint = requireAll(`${__dirname}/commitlint`);
+const eslint = requireAll({
+  dirname: path.resolve(__dirname, 'eslint'),
+});
+const stylelint = requireAll({
+  dirname: path.resolve(__dirname, 'stylelint'),
+});
+const prettier = requireAll({
+  dirname: path.resolve(__dirname, 'prettier'),
+});
+const commitlint = requireAll({
+  dirname: path.resolve(__dirname, 'commitlint'),
+});
 
 function getConfig(configs, rule, customConfig) {
   if (!configs[rule]) {


### PR DESCRIPTION
使用 Jest 跑测试代码时，会找不到 `plugin:@iceworks/best-practices/react-ts`

解决方案参考链接：https://github.com/vuejs/eslint-plugin-vue/issues/290
