### PR TITLE
Feat add line-height unitless check

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,5 +3,9 @@ const { getESLintConfig } = require('./packages/spec/src/');
 module.exports = getESLintConfig('react', {
   env: {
     jest: true
+  },
+  rules: {
+    // For test file. This project is no UI project, not use line height.
+    '@iceworks/best-practices/recommend-add-line-height-unit': 'off'
   }
 });

--- a/packages/eslint-plugin-best-practices/docs/rules/recommend-add-line-height-unit.md
+++ b/packages/eslint-plugin-best-practices/docs/rules/recommend-add-line-height-unit.md
@@ -1,0 +1,39 @@
+# recommend-functional-component
+
+Recommended to add unit for line-height which is more than 5.
+
+## Rule Details
+
+Examples of **incorrect** code for this rule:
+
+```js
+class App extends React.Component {
+  render() {
+    return <p style={lineHeight: 10}>hello world</p>;
+  }
+}
+```
+
+```css
+.text {
+  line-height: 10;
+}
+```
+
+Should add unit for line-height, like `line-height: 10px;`;
+
+Examples of **correct** code for this rule:
+
+```js
+class App extends React.Component {
+  render() {
+    return <p style={lineHeight: 2}>hello world</p>;
+  }
+}
+```
+
+```css
+.text {
+  line-height: 2;
+}
+```

--- a/packages/eslint-plugin-best-practices/package.json
+++ b/packages/eslint-plugin-best-practices/package.json
@@ -21,6 +21,7 @@
     "@iceworks/spec": "^1.0.0",
     "@mdn/browser-compat-data": "^2.0.3",
     "fs-extra": "^9.0.1",
+    "glob": "^7.1.6",
     "line-column": "^1.0.2",
     "path-to-regexp": "^6.1.0",
     "require-all": "^3.0.0",

--- a/packages/eslint-plugin-best-practices/src/configs/common.js
+++ b/packages/eslint-plugin-best-practices/src/configs/common.js
@@ -24,6 +24,7 @@ module.exports = {
     '@iceworks/best-practices/no-js-in-ts-project': 'warn',
     '@iceworks/best-practices/no-lowercase-component-name': 'warn',
     '@iceworks/best-practices/no-secret-info': 'error',
+    '@iceworks/best-practices/recommend-add-line-height-unit': 'error',
     '@iceworks/best-practices/recommend-functional-component': 'warn',
     '@iceworks/best-practices/recommend-polyfill': 'warn',
   },

--- a/packages/eslint-plugin-best-practices/src/rules/recommend-add-line-height-unit.js
+++ b/packages/eslint-plugin-best-practices/src/rules/recommend-add-line-height-unit.js
@@ -34,7 +34,7 @@ const getCheckAndReportFn = (context) => {
         });
       }
     }
-  }
+  };
 };
 
 module.exports = {

--- a/packages/eslint-plugin-best-practices/src/rules/recommend-add-line-height-unit.js
+++ b/packages/eslint-plugin-best-practices/src/rules/recommend-add-line-height-unit.js
@@ -1,0 +1,74 @@
+const fs = require('fs');
+const path = require('path');
+const lineColumn = require('line-column');
+const docsUrl = require('../docsUrl');
+const { glob } = require('glob');
+
+const RULE_NAME = 'recommend-add-line-height-unit';
+
+const CSS_REG = /line-height:([\s\d]+);/g;
+const JSX_REG = /lineHeight:([\s\d]+)/g;
+
+const FILE_CACHE = {};
+
+const getCheckAndReportFn = (context) => {
+  return (sourceCodeText, fileType, basename) => {
+    let matched;
+    const reg = fileType === 'jsx' ? JSX_REG : CSS_REG;
+    // eslint-disable-next-line
+    while ((matched = reg.exec(sourceCodeText)) !== null) {
+      const target = matched[0];
+      const value = matched[1];
+
+      // line height > 5 need add unit
+      if (Number(value) > 5) {
+        const startPosition = lineColumn(sourceCodeText).fromIndex(matched.index);
+
+        context.report({
+          loc: {
+            start: { line: startPosition.line, column: startPosition.col },
+            end: { line: startPosition.line, column: startPosition.col + target.length },
+          },
+          messageId: 'recommendAddLineHeightUnit',
+          data: { target, basename },
+        });
+      }
+    }
+  }
+};
+
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      url: docsUrl(RULE_NAME),
+    },
+    fixable: null,
+    messages: {
+      // eslint-disable-next-line
+      recommendAddLineHeightUnit: 'Please add unit (like px, rpx ...) for "{{target}}" in "{{basename}}".',
+    },
+  },
+
+  create(context) {
+    const checkAndReport = getCheckAndReportFn(context);
+
+    const fileName = context.getFilename();
+    const dirname = path.dirname(fileName);
+
+    const sourceCode = context.getSourceCode();
+    const sourceCodeText = sourceCode.getText();
+
+    checkAndReport(sourceCodeText, 'jsx', path.basename(fileName));
+
+    glob.sync(`${dirname}/*.{css,scss,less}`).forEach((cssFileName) => {
+      if (!FILE_CACHE[cssFileName]) {
+        FILE_CACHE[cssFileName] = true;
+        checkAndReport(fs.readFileSync(cssFileName, 'utf-8'), 'css', path.basename(cssFileName));
+      }
+    });
+
+    // Necessary
+    return {};
+  },
+};

--- a/packages/eslint-plugin-best-practices/test/src/rules/recommend-add-line-height-unit.test.js
+++ b/packages/eslint-plugin-best-practices/test/src/rules/recommend-add-line-height-unit.test.js
@@ -1,0 +1,41 @@
+'use strict';
+
+const rule = require('../../../src/rules/recommend-add-line-height-unit');
+const { RuleTester } = require('eslint');
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('recommend-add-line-height-unit', rule, {
+  valid: [
+    {
+      filename: 'index.js',
+      code: 'var style = { position: "relative", lineHeight: "30px" };',
+    },
+  ],
+
+  invalid: [
+    {
+      filename: 'index.js',
+      code: 'var style = { position: "relative", lineHeight: 30 };',
+      errors: [
+        {
+          message: 'Please add unit (like px, rpx ...) for "lineHeight: 30 " in "index.js".',
+        },
+      ],
+    },
+    {
+      filename: 'index.jsx',
+      code: '<p style={{ lineHeight: 10 }}>hello world</p>',
+      parserOptions: {
+        ecmaFeatures: {
+          jsx: true,
+        },
+      },
+      errors: [
+        {
+          message: 'Please add unit (like px, rpx ...) for "lineHeight: 10 " in "index.jsx".',
+        },
+      ],
+    },
+  ],
+});


### PR DESCRIPTION
# recommend-functional-component

Recommended to add unit for line-height which is more than 5.

## Rule Details

Examples of **incorrect** code for this rule:

```js
class App extends React.Component {
  render() {
    return <p style={lineHeight: 10}>hello world</p>;
  }
}
```

```css
.text {
  line-height: 10;
}
```

Should add unit for line-height, like `line-height: 10px;`;

Examples of **correct** code for this rule:

```js
class App extends React.Component {
  render() {
    return <p style={lineHeight: 2}>hello world</p>;
  }
}
```

```css
.text {
  line-height: 2;
}
```
