### PR TITLE
fix: Eslint says all enums in Typescript app are “already declared in…

### DIFF
--- a/packages/spec/src/eslint/rax-ts.js
+++ b/packages/spec/src/eslint/rax-ts.js
@@ -6,4 +6,8 @@ module.exports = {
     // For some ci and jest test env, we chose require.resolve instead 'plugin:@iceworks/best-practices/rax-ts'
     require.resolve('@iceworks/eslint-plugin-best-practices/src/configs/rax-ts'),
   ],
+  rules: {
+    'no-shadow': 'off',
+    '@typescript-eslint/no-shadow': ['error'],
+  },
 };

--- a/packages/spec/src/eslint/react-ts.js
+++ b/packages/spec/src/eslint/react-ts.js
@@ -6,4 +6,8 @@ module.exports = {
     // For some ci and jest test env, we chose require.resolve instead 'plugin:@iceworks/best-practices/react-ts'
     require.resolve('@iceworks/eslint-plugin-best-practices/src/configs/react-ts'),
   ],
+  rules: {
+    'no-shadow': 'off',
+    '@typescript-eslint/no-shadow': ['error'],
+  },
 };


### PR DESCRIPTION
  Eslint says all enums in Typescript app are “already declared in the upper scope”
 
问题引用：
* stackoverflow链接： https://stackoverflow.com/questions/63961803/eslint-says-all-enums-in-typescript-app-are-already-declared-in-the-upper-scope
* eslint-plugin/docs/rules/no-shadow.md：https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-shadow.md#how-to-use 
