### PR TITLE
feat: add common rules

### DIFF
--- a/packages/spec/.eslintrc.common-ts.js
+++ b/packages/spec/.eslintrc.common-ts.js
@@ -1,0 +1,7 @@
+const { getESLintConfig } = require('./src');
+
+module.exports = getESLintConfig('common-ts', {
+  env: {
+    jest: true,
+  },
+});

--- a/packages/spec/.eslintrc.common.js
+++ b/packages/spec/.eslintrc.common.js
@@ -1,0 +1,7 @@
+const { getESLintConfig } = require('./src');
+
+module.exports = getESLintConfig('common', {
+  env: {
+    jest: true,
+  },
+});

--- a/packages/spec/CHANGELOG.md
+++ b/packages/spec/CHANGELOG.md
@@ -1,4 +1,8 @@
 # changelog
 
+## 1.2.0
+- ESlint config support `common` and `common-ts` rules.
+- Commitlint, prettier, stylelint config support `common` rules.
+
 ## 1.1.0
 - Support `vue` and `vue-ts` project.

--- a/packages/spec/README.md
+++ b/packages/spec/README.md
@@ -28,8 +28,8 @@ First create a `.eslintrc.js` file. Then edit your config.
 // .eslintrc.js
 const { getESLintConfig } = require('@iceworks/spec');
 
-// getESLintConfig(rule: 'rax'|'react'|'vue' , customConfig?);
-module.exports = getESLintConfig('react');
+// getESLintConfig(rule: 'common'|'rax'|'react'|'vue' , customConfig?);
+module.exports = getESLintConfig('common');
 ```
 
 ##### TypeScript + [rax](https://rax.js.org/), [ice](https://ice.work/) and react
@@ -40,8 +40,8 @@ module.exports = getESLintConfig('react');
 // .eslintrc.js
 const { getESLintConfig } = require('@iceworks/spec');
 
-// getESLintConfig(rule: 'rax-ts'|'react-ts'|'vue-ts', customConfig?);
-module.exports = getESLintConfig('react-ts');
+// getESLintConfig(rule: 'common-ts'|'rax-ts'|'react-ts'|'vue-ts', customConfig?);
+module.exports = getESLintConfig('common-ts');
 ```
 
 ### stylelint
@@ -58,7 +58,7 @@ First create a `.stylelintrc.js` file. Then edit your config.
 // .stylelintrc.js
 const { getStylelintConfig } = require('@iceworks/spec');
 
-// getStylelintConfig(rule: 'rax'|'react'|'vue', customConfig?);
+// getStylelintConfig(rule: 'common'|'rax'|'react'|'vue', customConfig?);
 module.exports = getStylelintConfig('react');
 ```
 
@@ -74,7 +74,7 @@ First create a `.prettierrc.js` file. Then edit your config.
 // .prettierrc.js
 const { getPrettierConfig } = require('@iceworks/spec');
 
-// getPrettierConfig(rule: 'rax'|'react'|'vue', customConfig?);
+// getPrettierConfig(rule: 'common'|'rax'|'react'|'vue', customConfig?);
 module.exports = getPrettierConfig('react');
 ```
 
@@ -92,7 +92,7 @@ First create a `.commitlintrc.js` file. Then edit your config.
 // .commitlintrc.js
 const { getCommitlintConfig } = require('@iceworks/spec');
 
-// getCommitlintConfig(rule: 'rax'|'react'|'vue', customConfig?);
+// getCommitlintConfig(rule: 'common'|'rax'|'react'|'vue', customConfig?);
 module.exports = getCommitlintConfig('react');
 ```
 
@@ -104,7 +104,7 @@ module.exports = getCommitlintConfig('react');
 // .eslintrc.js
 const { getESLintConfig } = require('@iceworks/spec');
 
-// getESLintConfig(rule: 'rax'|'react'|'vue', customConfig?);
+// getESLintConfig(rule: 'common'|'rax'|'react'|'vue', customConfig?);
 module.exports = getESLintConfig('rax', {
   // custom config it will merge into main config
   rules: {

--- a/packages/spec/examples/common-ts/index.ts
+++ b/packages/spec/examples/common-ts/index.ts
@@ -1,0 +1,7 @@
+interface AppDeveloper {
+  name: string;
+  id: number;
+}
+
+const bar = [1, 2];
+const one: AppDeveloper = { name: 'hello', id: 1 };

--- a/packages/spec/examples/common/index.js
+++ b/packages/spec/examples/common/index.js
@@ -1,0 +1,2 @@
+const foo = [1, 2];
+console.log(foo);

--- a/packages/spec/package.json
+++ b/packages/spec/package.json
@@ -1,19 +1,21 @@
 {
   "name": "@iceworks/spec",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Easy to use eslint/stylelint/prettier/commitlint in rax, ice and react project.",
   "main": "src/index.js",
   "files": [
     "src"
   ],
   "scripts": {
+    "eslint-common": "eslint -c .eslintrc.common.js --ext .js,.jsx ./examples/common/",
+    "eslint-common-ts": "eslint -c .eslintrc.common-ts.js --ext .ts,.tsx ./examples/common-ts/",
     "eslint-rax": "eslint -c .eslintrc.rax.js --ext .js,.jsx ./examples/rax/",
     "eslint-rax-ts": "eslint -c .eslintrc.rax-ts.js --ext .ts,.tsx ./examples/rax-ts/",
     "eslint-react": "eslint -c .eslintrc.react.js --ext .js,.jsx ./examples/react/",
     "eslint-react-ts": "eslint -c .eslintrc.react-ts.js --ext .ts,.tsx ./examples/react-ts/",
     "eslint-vue": "eslint -c .eslintrc.vue.js --ext .vue ./examples/vue/",
     "eslint-vue-ts": "eslint -c .eslintrc.vue-ts.js --ext .vue ./examples/vue-ts/",
-    "eslint-test": "npm run eslint-rax && npm run eslint-rax-ts && npm run eslint-react && npm run eslint-react-ts && npm run eslint-vue && npm run eslint-vue-ts",
+    "eslint-test": "npm run eslint-common && npm run eslint-common-ts && npm run eslint-rax && npm run eslint-rax-ts && npm run eslint-react && npm run eslint-react-ts && npm run eslint-vue && npm run eslint-vue-ts",
     "stylelin-test": "stylelint ./**/*.{css,scss,vue}",
     "test": "npm run eslint-test && npm run stylelin-test",
     "prepublishOnly": "npm run test"

--- a/packages/spec/src/commitlint/common.js
+++ b/packages/spec/src/commitlint/common.js
@@ -1,0 +1,4 @@
+// commitlint config for common project
+module.exports = {
+  extends: 'ali',
+};

--- a/packages/spec/src/eslint/common-ts.js
+++ b/packages/spec/src/eslint/common-ts.js
@@ -1,0 +1,11 @@
+// https://www.npmjs.com/package/eslint-config-ali
+// ESlint config for common ts project
+module.exports = {
+  extends: [
+    require.resolve('eslint-config-ali/typescript'),
+  ],
+  rules: {
+    // Change error to warn
+    '@typescript-eslint/no-unused-vars': 'warn',
+  },
+};

--- a/packages/spec/src/eslint/common.js
+++ b/packages/spec/src/eslint/common.js
@@ -1,0 +1,11 @@
+// https://www.npmjs.com/package/eslint-config-ali
+// ESlint config for common js project
+module.exports = {
+  extends: [
+    require.resolve('eslint-config-ali'),
+  ],
+  rules: {
+    // Change error to warn
+    'no-unused-vars': 'warn',
+  },
+};

--- a/packages/spec/src/prettier/common.js
+++ b/packages/spec/src/prettier/common.js
@@ -1,0 +1,8 @@
+// prettier config for common project
+module.exports = {
+  printWidth: 120,
+  tabWidth: 2,
+  semi: true,
+  singleQuote: true,
+  trailingComma: 'all',
+};

--- a/packages/spec/src/stylelint/common.js
+++ b/packages/spec/src/stylelint/common.js
@@ -1,0 +1,5 @@
+// https://www.npmjs.com/package/stylelint-config-ali
+// stylelint config for common project
+module.exports = {
+  extends: 'stylelint-config-ali',
+};


### PR DESCRIPTION
增加通用检测规则，支持更多通用类型项目

```javascript
// .eslintrc.js
const { getESLintConfig } = require('@iceworks/spec');

// 增加 common 和 common-ts ，支持所有 js 和 ts 项目
module.exports = getESLintConfig('common');
```

未能自动识别出框架的项目，可使用通用规则进行 eslint 扫描