### PR TITLE
Feat update ESLint 7.x

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,10 +2,10 @@ const { getESLintConfig } = require('./packages/spec/src/');
 
 module.exports = getESLintConfig('react', {
   env: {
-    jest: true
+    jest: true,
   },
   rules: {
     // For test file. This project is no UI project, not use line height.
-    '@iceworks/best-practices/recommend-add-line-height-unit': 'off'
-  }
+    '@iceworks/best-practices/recommend-add-line-height-unit': 'off',
+  },
 });

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,9 +1,6 @@
 const { getESLintConfig } = require('./packages/spec/src/');
 
 module.exports = getESLintConfig('react', {
-  env: {
-    jest: true,
-  },
   rules: {
     // For test file. This project is no UI project, not use line height.
     '@iceworks/best-practices/recommend-add-line-height-unit': 'off',

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@commitlint/cli": "^11.0.0",
     "codecov": "^3.6.1",
     "commitlint-config-ali": "^0.1.0",
-    "eslint": "^6.8.0",
+    "eslint": "^7.22.0",
     "husky": "^4.3.0",
     "ice-npm-utils": "^2.0.1",
     "jest": "^24.9.0",

--- a/packages/eslint-plugin-best-practices/CHANGELOG.md
+++ b/packages/eslint-plugin-best-practices/CHANGELOG.md
@@ -1,0 +1,4 @@
+# changelog
+
+## 0.2.8
+- Update ESLint 7.x

--- a/packages/eslint-plugin-best-practices/CHANGELOG.md
+++ b/packages/eslint-plugin-best-practices/CHANGELOG.md
@@ -2,3 +2,4 @@
 
 ## 0.2.8
 - Update ESLint 7.x
+- Overrides `**/__tests__/*.{j,t}s?(x)` and `**/tests/*.{j,t}s?(x)` env config to `jest: true`

--- a/packages/eslint-plugin-best-practices/CHANGELOG.md
+++ b/packages/eslint-plugin-best-practices/CHANGELOG.md
@@ -1,5 +1,6 @@
 # changelog
 
 ## 0.2.8
-- Update ESLint 7.x
+
+- Update ESLint from 6.x to 7.x
 - Overrides `**/__tests__/*.{j,t}s?(x)` and `**/tests/*.{j,t}s?(x)` env config to `jest: true`

--- a/packages/eslint-plugin-best-practices/CHANGELOG.md
+++ b/packages/eslint-plugin-best-practices/CHANGELOG.md
@@ -3,4 +3,4 @@
 ## 0.2.8
 
 - Update ESLint from 6.x to 7.x
-- Overrides `**/__tests__/*.{j,t}s?(x)` and `**/tests/*.{j,t}s?(x)` env config to `jest: true`
+- Overrides `**/__tests__/*.{j,t}s?(x)`, `**/__tests__/*.{j,t}s?(x)` and `**/test/*.{j,t}s?(x)` env config `jest: true`

--- a/packages/eslint-plugin-best-practices/package.json
+++ b/packages/eslint-plugin-best-practices/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iceworks/eslint-plugin-best-practices",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "Iceworks best practices eslint plugin.",
   "files": [
     "docs/",
@@ -28,6 +28,6 @@
     "semver": "^7.3.2"
   },
   "devDependencies": {
-    "eslint": "^6.8.0"
+    "eslint": "^7.22.0"
   }
 }

--- a/packages/eslint-plugin-best-practices/src/configs/common.js
+++ b/packages/eslint-plugin-best-practices/src/configs/common.js
@@ -17,6 +17,15 @@ module.exports = {
         '@iceworks/best-practices/recommend-update-rax': 'warn',
       },
     },
+    {
+      files: [
+        "**/__tests__/*.{j,t}s?(x)",
+        "**/tests/*.{j,t}s?(x)"
+      ],
+      env: {
+        jest: true
+      }
+    }
   ],
   rules: {
     'max-len': ['warn', 120, 2, {

--- a/packages/eslint-plugin-best-practices/src/configs/common.js
+++ b/packages/eslint-plugin-best-practices/src/configs/common.js
@@ -19,12 +19,10 @@ module.exports = {
     },
     {
       files: [
-        "**/__tests__/*.{j,t}s?(x)",
-        "**/tests/*.{j,t}s?(x)"
+        '**/__tests__/*.{j,t}s?(x)',
+        '**/tests/*.{j,t}s?(x)',
       ],
-      env: {
-        jest: true
-      }
+      env: { jest: true }
     }
   ],
   rules: {

--- a/packages/eslint-plugin-best-practices/src/configs/common.js
+++ b/packages/eslint-plugin-best-practices/src/configs/common.js
@@ -21,6 +21,7 @@ module.exports = {
       files: [
         '**/__tests__/*.{j,t}s?(x)',
         '**/tests/*.{j,t}s?(x)',
+        '**/test/*.{j,t}s?(x)',
       ],
       env: { jest: true },
     },

--- a/packages/eslint-plugin-best-practices/src/configs/common.js
+++ b/packages/eslint-plugin-best-practices/src/configs/common.js
@@ -22,8 +22,8 @@ module.exports = {
         '**/__tests__/*.{j,t}s?(x)',
         '**/tests/*.{j,t}s?(x)',
       ],
-      env: { jest: true }
-    }
+      env: { jest: true },
+    },
   ],
   rules: {
     'max-len': ['warn', 120, 2, {

--- a/packages/spec/.eslintrc.common-ts.js
+++ b/packages/spec/.eslintrc.common-ts.js
@@ -1,7 +1,3 @@
 const { getESLintConfig } = require('./src');
 
-module.exports = getESLintConfig('common-ts', {
-  env: {
-    jest: true,
-  },
-});
+module.exports = getESLintConfig('common-ts');

--- a/packages/spec/.eslintrc.common.js
+++ b/packages/spec/.eslintrc.common.js
@@ -1,7 +1,3 @@
 const { getESLintConfig } = require('./src');
 
-module.exports = getESLintConfig('common', {
-  env: {
-    jest: true,
-  },
-});
+module.exports = getESLintConfig('common');

--- a/packages/spec/.eslintrc.rax-ts.js
+++ b/packages/spec/.eslintrc.rax-ts.js
@@ -1,7 +1,3 @@
 const { getESLintConfig } = require('./src');
 
-module.exports = getESLintConfig('rax-ts', {
-  env: {
-    jest: true,
-  },
-});
+module.exports = getESLintConfig('rax-ts');

--- a/packages/spec/.eslintrc.rax.js
+++ b/packages/spec/.eslintrc.rax.js
@@ -1,7 +1,3 @@
 const { getESLintConfig } = require('./src');
 
-module.exports = getESLintConfig('rax', {
-  env: {
-    jest: true,
-  },
-});
+module.exports = getESLintConfig('rax');

--- a/packages/spec/.eslintrc.react-ts.js
+++ b/packages/spec/.eslintrc.react-ts.js
@@ -1,7 +1,3 @@
 const { getESLintConfig } = require('./src');
 
-module.exports = getESLintConfig('react-ts', {
-  env: {
-    jest: true,
-  },
-});
+module.exports = getESLintConfig('react-ts');

--- a/packages/spec/.eslintrc.react.js
+++ b/packages/spec/.eslintrc.react.js
@@ -1,7 +1,3 @@
 const { getESLintConfig } = require('./src');
 
-module.exports = getESLintConfig('react', {
-  env: {
-    jest: true,
-  },
-});
+module.exports = getESLintConfig('react');

--- a/packages/spec/.eslintrc.vue-ts.js
+++ b/packages/spec/.eslintrc.vue-ts.js
@@ -1,7 +1,3 @@
 const { getESLintConfig } = require('./src');
 
-module.exports = getESLintConfig('vue-ts', {
-  env: {
-    jest: true,
-  },
-});
+module.exports = getESLintConfig('vue-ts');

--- a/packages/spec/.eslintrc.vue.js
+++ b/packages/spec/.eslintrc.vue.js
@@ -1,7 +1,3 @@
 const { getESLintConfig } = require('./src');
 
-module.exports = getESLintConfig('vue', {
-  env: {
-    jest: true,
-  },
-});
+module.exports = getESLintConfig('vue');

--- a/packages/spec/CHANGELOG.md
+++ b/packages/spec/CHANGELOG.md
@@ -1,5 +1,9 @@
 # changelog
 
+## 1.3.0
+- Update ESLint 7.x
+- Update eslint-config-ali 12.x
+
 ## 1.2.0
 - ESlint config support `common` and `common-ts` rules.
 - Commitlint, prettier, stylelint config support `common` rules.

--- a/packages/spec/CHANGELOG.md
+++ b/packages/spec/CHANGELOG.md
@@ -1,12 +1,15 @@
 # changelog
 
 ## 1.3.0
-- Update ESLint 7.x
-- Update eslint-config-ali 12.x
+
+- Update ESLint from 6.x to 7.x
+- Update eslint-config-ali from 11.x to 12.x
 
 ## 1.2.0
+
 - ESlint config support `common` and `common-ts` rules.
 - Commitlint, prettier, stylelint config support `common` rules.
 
 ## 1.1.0
+
 - Support `vue` and `vue-ts` project.

--- a/packages/spec/package.json
+++ b/packages/spec/package.json
@@ -1,20 +1,20 @@
 {
   "name": "@iceworks/spec",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Easy to use eslint/stylelint/prettier/commitlint in rax, ice and react project.",
   "main": "src/index.js",
   "files": [
     "src"
   ],
   "scripts": {
-    "eslint-common": "eslint -c .eslintrc.common.js --ext .js,.jsx ./examples/common/",
-    "eslint-common-ts": "eslint -c .eslintrc.common-ts.js --ext .ts,.tsx ./examples/common-ts/",
-    "eslint-rax": "eslint -c .eslintrc.rax.js --ext .js,.jsx ./examples/rax/",
-    "eslint-rax-ts": "eslint -c .eslintrc.rax-ts.js --ext .ts,.tsx ./examples/rax-ts/",
-    "eslint-react": "eslint -c .eslintrc.react.js --ext .js,.jsx ./examples/react/",
-    "eslint-react-ts": "eslint -c .eslintrc.react-ts.js --ext .ts,.tsx ./examples/react-ts/",
-    "eslint-vue": "eslint -c .eslintrc.vue.js --ext .vue ./examples/vue/",
-    "eslint-vue-ts": "eslint -c .eslintrc.vue-ts.js --ext .vue ./examples/vue-ts/",
+    "eslint-common": "eslint --no-eslintrc -c .eslintrc.common.js --ext .js,.jsx ./examples/common/",
+    "eslint-common-ts": "eslint --no-eslintrc -c .eslintrc.common-ts.js --ext .ts,.tsx ./examples/common-ts/",
+    "eslint-rax": "eslint --no-eslintrc -c .eslintrc.rax.js --ext .js,.jsx ./examples/rax/",
+    "eslint-rax-ts": "eslint --no-eslintrc -c .eslintrc.rax-ts.js --ext .ts,.tsx ./examples/rax-ts/",
+    "eslint-react": "eslint --no-eslintrc -c .eslintrc.react.js --ext .js,.jsx ./examples/react/",
+    "eslint-react-ts": "eslint --no-eslintrc -c .eslintrc.react-ts.js --ext .ts,.tsx ./examples/react-ts/",
+    "eslint-vue": "eslint --no-eslintrc -c .eslintrc.vue.js --ext .vue ./examples/vue/",
+    "eslint-vue-ts": "eslint --no-eslintrc -c .eslintrc.vue-ts.js --ext .vue ./examples/vue-ts/",
     "eslint-test": "npm run eslint-common && npm run eslint-common-ts && npm run eslint-rax && npm run eslint-rax-ts && npm run eslint-react && npm run eslint-react-ts && npm run eslint-vue && npm run eslint-vue-ts",
     "stylelin-test": "stylelint ./**/*.{css,scss,vue}",
     "test": "npm run eslint-test && npm run stylelin-test",
@@ -32,7 +32,7 @@
   },
   "homepage": "https://github.com/ice-lab/spec#readme",
   "peerDependencies": {
-    "eslint": "^6.8.0"
+    "eslint": ">=6.8.0"
   },
   "dependencies": {
     "@iceworks/eslint-plugin-best-practices": "^0.2.0",
@@ -40,18 +40,18 @@
     "@typescript-eslint/parser": "^4.5.0",
     "babel-eslint": "^10.1.0",
     "commitlint-config-ali": "^0.1.0",
-    "eslint-config-ali": "^11.1.0",
+    "eslint-config-ali": "^12.0.1",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-react": "^7.21.5",
     "eslint-plugin-react-hooks": "^4.2.0",
-    "eslint-plugin-vue": "^6.2.2",
+    "eslint-plugin-vue": "^7.3.0",
     "require-all": "^3.0.0",
     "stylelint-config-ali": "^0.3.4",
     "stylelint-scss": "^3.18.0",
     "vue-eslint-parser": "^7.2.0"
   },
   "devDependencies": {
-    "eslint": "^6.8.0",
+    "eslint": "^7.22.0",
     "jest": "^24.9.0",
     "prettier": "^2.1.0",
     "rax": "^1.1.0",


### PR DESCRIPTION
* 更新 ESLint 依赖至 7.x
* 更新 eslint-config-ali 至 12.x
* 指定  `**/__tests__/*.{j,t}s?(x)`，`**/tests/*.{j,t}s?(x)` 和 `**/test/*.{j,t}s?(x)` env `jest: true`

项目单测及示例项目测试通过。
和 eslint-config-ali 维护者也确认过是向下兼容的，规则配置无更新，非 breakchange