### PR TITLE
Feat support rax jsx plus

### DIFF
--- a/packages/spec/CHANGELOG.md
+++ b/packages/spec/CHANGELOG.md
@@ -1,5 +1,9 @@
 # changelog
 
+## 1.3.2
+
+- Add [eslint-plugin-jsx-plus](https://github.com/jsx-plus/eslint-plugin-jsx-plus) support Rax JSX+.
+
 ## 1.3.1
 
 - Add stylelint peerDependencies

--- a/packages/spec/package.json
+++ b/packages/spec/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iceworks/spec",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Easy to use eslint/stylelint/prettier/commitlint in rax, ice and react project.",
   "main": "src/index.js",
   "files": [
@@ -43,6 +43,7 @@
     "commitlint-config-ali": "^0.1.0",
     "eslint-config-ali": "^12.0.1",
     "eslint-plugin-import": "^2.22.1",
+    "eslint-plugin-jsx-plus": "^0.1.0",
     "eslint-plugin-react": "^7.21.5",
     "eslint-plugin-react-hooks": "^4.2.0",
     "eslint-plugin-vue": "^7.3.0",


### PR DESCRIPTION
Add [eslint-plugin-jsx-plus](https://github.com/jsx-plus/eslint-plugin-jsx-plus) 

Support: 

```jsx
import { createElement } from 'rax';
import Text from 'rax-text';

export default (props) => {
  const { uri } = props;
  const test = ['hello', 'world', uri];
  return (
    <Text x-for={item in test} key={item}>
      {item}
    </Text>
  );
};
```